### PR TITLE
"TF2_OnBuildingLanded" and "TF2_OnTossBuildingPost" forwards fix + New params for "TF2_OnTossBuildingPost"

### DIFF
--- a/tossbuildings.inc
+++ b/tossbuildings.inc
@@ -29,11 +29,12 @@ forward Action TF2_OnTossBuilding(int building, int objectType, int owner);
  * Player has just thrown a building
  * 
  * @param building - entity index of the building, doesn't change from the moment the building is SELECTED
+ * @param phys - entity index of the prop pretending to be a building to display the throw 
  * @param objectType - type of BUILDING_*
  * @param owner - the player currently trying to throw the building
  * @noreturn
  */
-forward void TF2_OnTossBuildingPost(int building, int objectType, int owner);
+forward void TF2_OnTossBuildingPost(int building, int phys, int objectType, int owner);
 
 /**
  * The building has landed. Not guaranteed to be called after a throw (class might change, etc).

--- a/tossbuildings.sp
+++ b/tossbuildings.sp
@@ -703,7 +703,7 @@ public Action ValidateBuilding(Handle timer, any building) {
 	if (invalid) BreakBuilding(obj);
 	if (g_fwdLanded.FunctionCount>0) {
 		Call_StartForward(g_fwdLanded);
-		Call_PushCell(building);
+		Call_PushCell(obj);
 		Call_PushCell(!invalid);
 		Call_Finish();
 	}

--- a/tossbuildings.sp
+++ b/tossbuildings.sp
@@ -141,7 +141,7 @@ public void OnPluginStart() {
 	
 	//let other plugins integrate :)
 	g_fwdToss = CreateGlobalForward("TF2_OnTossBuilding", ET_Event, Param_Cell, Param_Cell, Param_Cell);
-	g_fwdTossPost = CreateGlobalForward("TF2_OnTossBuildingPost", ET_Ignore, Param_Cell, Param_Cell, Param_Cell);
+	g_fwdTossPost = CreateGlobalForward("TF2_OnTossBuildingPost", ET_Ignore, Param_Cell, Param_Cell, Param_Cell, Param_Cell);
 	g_fwdLanded = CreateGlobalForward("TF2_OnBuildingLanded", ET_Ignore, Param_Cell, Param_Cell);
 }
 public void LockConVar(ConVar convar, const char[] oldValue, const char[] newValue) {
@@ -402,8 +402,9 @@ public void ThrowBuilding(any buildref) {
 	g_aAirbornObjects.PushArray(onade);
 	
 	if (g_fwdTossPost.FunctionCount>0) {
-		Call_StartForward(g_fwdToss);
+		Call_StartForward(g_fwdTossPost);
 		Call_PushCell(building);
+		Call_PushCell(phys);
 		Call_PushCell(type);
 		Call_PushCell(owner);
 		Call_Finish();


### PR DESCRIPTION
Instead of pushing building's entity index to call, the plugin pushes an entity reference to "TF2_OnBuildingLanded" forward.
